### PR TITLE
Resolves bug #550 by fixing the division by zero problem

### DIFF
--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -333,7 +333,7 @@ class Draw extends PointerInteraction {
            * +-------+------<3>-- (the third point may be anywhere on this line)
            */
 
-          if (coordinates.length > 2) {
+           if (coordinates.length > 2) {
             var first = coordinates[0];
             var second = coordinates[1];
             var third = coordinates[2];
@@ -341,19 +341,17 @@ class Draw extends PointerInteraction {
             // vector from first to second
             var a_vec = [second[0] - first[0], second[1] - first[1]];
 
-            if (a_vec[1] === 0) {
+            if (a_vec[0] === 0 && a_vec[1] === 0) {
                 // catch the case where the first and second point are equal
-                coordinates = [[first, first, first, first]];
+                coordinates = [[first]];
             } else {
               // perpendicular vector to a_vec
               var b_vec = [-1 * a_vec[1], a_vec[0]];
 
-              // helper
-              var tmp = a_vec[0] / a_vec[1];
               // compute the intersection parameter of the two lines
               // going from second in b_vec direction
               // and from third in a_vec direction
-              var x = (third[0] + tmp * (second[1] - third[1]) - second[0]) / (b_vec[0] - b_vec[1] * tmp);
+              var x = (third[0] * second[1] - third[1] * second[0]) / (third[0] * b_vec[1] - third[1] * b_vec[0]);
 
               // vector from second to the intersection point
               var intersection_vec = [x * b_vec[0], x * b_vec[1]];

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -336,7 +336,7 @@ class Draw extends PointerInteraction {
           if (coordinates.length > 2) {
             var first = coordinates[0];
             var second = coordinates[1];
-            var third = coordinates[2];
+            var third = coordinates[2].every((element) => element === 0) ? [1e-7,1e-7] : coordinates[2];
 
             // vector from first to second
             var a_vec = [second[0] - first[0], second[1] - first[1]];
@@ -404,7 +404,7 @@ class Draw extends PointerInteraction {
           if (coordinates.length > 2) {
             var first = coordinates[0];
             var second = coordinates[1];
-            var third = coordinates[2];
+            var third = coordinates[2].every((element) => element === 0) ? [1e-7,1e-7] : coordinates[2];
 
             // vector from first to second
             var a_vec = [second[0] - first[0], second[1] - first[1]];

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -336,6 +336,7 @@ class Draw extends PointerInteraction {
           if (coordinates.length > 2) {
             var first = coordinates[0];
             var second = coordinates[1];
+            // Replace [0,0] by coordinate with small numbers to prevent division by zero error
             var third = coordinates[2].every((element) => element === 0) ? [1e-7,1e-7] : coordinates[2];
 
             // vector from first to second
@@ -915,6 +916,7 @@ class Draw extends PointerInteraction {
    * @private
    */
   addToDrawing_(event) {
+    // Check sketch coordinates for duplicates and discard them if present
     if(new Set(this.sketchCoords_.map(JSON.stringify)).size < this.sketchCoords_.length){
       return;
     }

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -333,7 +333,7 @@ class Draw extends PointerInteraction {
            * +-------+------<3>-- (the third point may be anywhere on this line)
            */
 
-           if (coordinates.length > 2) {
+          if (coordinates.length > 2) {
             var first = coordinates[0];
             var second = coordinates[1];
             var third = coordinates[2];

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -411,9 +411,9 @@ class Draw extends PointerInteraction {
             // Center point.
             var center = [first[0] + a_vec[0] * 0.5, first[1] + a_vec[1] * 0.5];
 
-            if (a_vec[1] === 0) {
+            if (a_vec[0] === 0 && a_vec[1] === 0) {
                 // catch the case where the first and second point are equal
-                coordinates = [[first, first, first, first]];
+                coordinates = [[first]];
             } else {
               // perpendicular vector to a_vec
               var b_vec = [-1 * a_vec[1], a_vec[0]];

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -336,8 +336,8 @@ class Draw extends PointerInteraction {
           if (coordinates.length > 2) {
             var first = coordinates[0];
             var second = coordinates[1];
-            // Replace [0,0] by coordinate with small numbers to prevent division by zero error
-            var third = coordinates[2].every((element) => element === 0) ? [1e-7,1e-7] : coordinates[2];
+            // Replace [0, 0] by coordinate with small numbers to prevent division by zero error for computation of x below.
+            var third = coordinates[2].every((element) => element === 0) ? [1e-7, 1e-7] : coordinates[2];
 
             // vector from first to second
             var a_vec = [second[0] - first[0], second[1] - first[1]];
@@ -405,7 +405,8 @@ class Draw extends PointerInteraction {
           if (coordinates.length > 2) {
             var first = coordinates[0];
             var second = coordinates[1];
-            var third = coordinates[2].every((element) => element === 0) ? [1e-7,1e-7] : coordinates[2];
+            // Replace [0, 0] by coordinate with small numbers to prevent division by zero error for computation of x below.
+            var third = coordinates[2].every((element) => element === 0) ? [1e-7, 1e-7] : coordinates[2];
 
             // vector from first to second
             var a_vec = [second[0] - first[0], second[1] - first[1]];
@@ -916,7 +917,8 @@ class Draw extends PointerInteraction {
    * @private
    */
   addToDrawing_(event) {
-    // Check sketch coordinates for duplicates and discard them if present
+    // Ignore event in case of duplicate coordinates (e.g. clicking on the same point twice).
+    // This was added to prevent incorrect states for the Rectangle and Ellipse shapes.
     if(new Set(this.sketchCoords_.map(JSON.stringify)).size < this.sketchCoords_.length){
       return;
     }

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -418,12 +418,10 @@ class Draw extends PointerInteraction {
               // perpendicular vector to a_vec
               var b_vec = [-1 * a_vec[1], a_vec[0]];
 
-              // helper
-              var tmp = a_vec[0] / a_vec[1];
               // compute the intersection parameter of the two lines
               // going from second in b_vec direction
               // and from third in a_vec direction
-              var x = (third[0] + tmp * (second[1] - third[1]) - second[0]) / (b_vec[0] - b_vec[1] * tmp);
+              var x = (third[0] * second[1] - third[1] * second[0]) / (third[0] * b_vec[1] - third[1] * b_vec[0]);
 
               // vector from second to the intersection point
               var intersection_vec = [x * b_vec[0], x * b_vec[1]];

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -915,6 +915,9 @@ class Draw extends PointerInteraction {
    * @private
    */
   addToDrawing_(event) {
+    if(new Set(this.sketchCoords_.map(JSON.stringify)).size < this.sketchCoords_.length){
+      return;
+    }
     const coordinate = event.coordinate;
     const geometry = /** @type {import("../geom/SimpleGeometry.js").default} */ (this.sketchFeature_.getGeometry());
     let done;


### PR DESCRIPTION
Perpendicular rectangles were catched in the wrong if-else branch. Fix condition by checking for equal points. Prevent division by zero problem by using alternative formula to compute interception parameter.